### PR TITLE
fix: include template in the REQUEST_FIELDS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Splunk Inc., 2024-2025
+   Copyright (c) Splunk Inc., 2024-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: ServiceDeskPlus
-Copyright (c) Splunk Inc., 2024-2025
+Copyright (c) Splunk Inc., 2024-2026

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ServiceDeskPlus
 
-Publisher: Splunk Inc. \
-Connector Version: 1.0.1 \
-Product Vendor: ManageEngine \
-Product Name: ServiceDeskPlus \
-Minimum Product Version: 6.1.1
+Publisher: Splunk Inc. <br>
+Connector Version: 1.0.1 <br>
+Product Vendor: ManageEngine <br>
+Product Name: ServiceDeskPlus <br>
+Minimum Product Version: 6.3.0
 
 This App supports a variety of ticket management actions on ManageEngine ServiceDesk Plus
 
@@ -61,23 +61,23 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[on poll](#action-on-poll) - Ingest tickets from ServiceDeskPlus \
-[delete ticket](#action-delete-ticket) - Delete ticket (request) \
-[create ticket](#action-create-ticket) - Create a ticket (request) \
-[update ticket](#action-update-ticket) - Update ticket (request) \
-[get ticket resolution](#action-get-ticket-resolution) - Get a resolution of the ticket (request) \
-[set ticket resolution](#action-set-ticket-resolution) - Add/Update a resolution of the ticket (request) \
-[list linked tickets](#action-list-linked-tickets) - Get all linked tickets under a ticket (request) \
-[assign ticket](#action-assign-ticket) - Assign a ticket (request) \
-[close ticket](#action-close-ticket) - Close a ticket (request) \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[on poll](#action-on-poll) - Ingest tickets from ServiceDeskPlus <br>
+[delete ticket](#action-delete-ticket) - Delete ticket (request) <br>
+[create ticket](#action-create-ticket) - Create a ticket (request) <br>
+[update ticket](#action-update-ticket) - Update ticket (request) <br>
+[get ticket resolution](#action-get-ticket-resolution) - Get a resolution of the ticket (request) <br>
+[set ticket resolution](#action-set-ticket-resolution) - Add/Update a resolution of the ticket (request) <br>
+[list linked tickets](#action-list-linked-tickets) - Get all linked tickets under a ticket (request) <br>
+[assign ticket](#action-assign-ticket) - Assign a ticket (request) <br>
+[close ticket](#action-close-ticket) - Close a ticket (request) <br>
 [list tickets](#action-list-tickets) - List tickets present in ServiceDesk Plus
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -92,7 +92,7 @@ No Output
 
 Ingest tickets from ServiceDeskPlus
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -113,7 +113,7 @@ No Output
 
 Delete ticket (request)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -139,7 +139,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create a ticket (request)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -165,7 +165,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Update ticket (request)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -196,7 +196,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get a resolution of the ticket (request)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -228,7 +228,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add/Update a resolution of the ticket (request)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -258,7 +258,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get all linked tickets under a ticket (request)
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -286,7 +286,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Assign a ticket (request)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -314,7 +314,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Close a ticket (request)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -348,7 +348,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List tickets present in ServiceDesk Plus
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -389,7 +389,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) Splunk Inc., 2024-2025
+# Copyright (c) Splunk Inc., 2024-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Updated REQUEST_FIELDS in servicedeskplus_const.py to include the "template" field.

--- a/servicedeskplus.json
+++ b/servicedeskplus.json
@@ -11,16 +11,19 @@
     "fips_compliant": false,
     "product_version_regex": ".*",
     "publisher": "Splunk Inc.",
-    "license": "Copyright (c) Splunk Inc., 2024-2025",
+    "license": "Copyright (c) Splunk Inc., 2024-2026",
     "app_version": "1.0.1",
     "utctime_updated": "2024-01-25T10:00:07.352934Z",
     "package_name": "phantom_servicedeskplus",
     "main_module": "servicedeskplus_connector.py",
-    "min_phantom_version": "6.1.1",
+    "min_phantom_version": "6.3.0",
     "app_wizard_version": "1.0.0",
     "contributors": [
         {
             "name": "Erica Pescio"
+        },
+        {
+            "name": "Diogo Silva"
         }
     ],
     "configuration": {
@@ -1041,5 +1044,8 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/servicedeskplus.json
+++ b/servicedeskplus.json
@@ -1047,5 +1047,8 @@
     ],
     "pip313_dependencies": {
         "wheel": []
+    },
+    "pip39_dependencies": {
+        "wheel": []
     }
 }

--- a/servicedeskplus_connector.py
+++ b/servicedeskplus_connector.py
@@ -1,6 +1,6 @@
 # File: servicedeskplus_connector.py
 #
-# Copyright (c) Splunk Inc., 2024-2025
+# Copyright (c) Splunk Inc., 2024-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/servicedeskplus_consts.py
+++ b/servicedeskplus_consts.py
@@ -1,6 +1,6 @@
 # File: servicedeskplus_consts.py
 #
-# Copyright (c) Splunk Inc., 2024-2025
+# Copyright (c) Splunk Inc., 2024-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ REQUEST_FIELDS = [
     "description",
     "request_type",
     "impact",
+    "template",
     "status",
     "mode",
     "level",


### PR DESCRIPTION
### Bug Fixes
- The "template" request field was not properly handled if passed in the fields input JSON. Even though the function get_query_params contains an if clause for "template", this is inside a loop on the fields in the REQUEST_FIELDS list which does not include the "template" field. Added "template" to the REQUEST_FIELDS in servicedeskplus_consts.py
